### PR TITLE
fix reference link to JQL grammar file

### DIFF
--- a/spec/src/main/asciidoc/chapters/language/query-language.adoc
+++ b/spec/src/main/asciidoc/chapters/language/query-language.adoc
@@ -507,5 +507,5 @@ The following grammar defines the syntax of JQL, via ANTLR4-style BNF.
 
 [source, antlrv4]
 ----
-include::../../antlr/JQL.g4[]
+include::../../../../antlr/JQL.g4[]
 ----


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the JQL grammar. The change corrects the relative path to the `JQL.g4` grammar file in the documentation include statement.