### PR TITLE
simplify the escape hatches for non-relational databases

### DIFF
--- a/spec/src/main/asciidoc/chapters/introduction/algebra.asciidoc
+++ b/spec/src/main/asciidoc/chapters/introduction/algebra.asciidoc
@@ -227,7 +227,7 @@ This time, `isbn` and `bookIsbn` agree.
 [[joins-nested]]
 ==== Joins to nested entities or collections
 
-Instead of named entity, a join may identify a structure or collection nested within the result list of the operation on which it acts:
+Instead of a named entity, a join may identify a structure or collection nested within the result list of the operation on which it acts:
 
 [source,sql]
 ----

--- a/spec/src/main/asciidoc/chapters/language/expressions.adoc
+++ b/spec/src/main/asciidoc/chapters/language/expressions.adoc
@@ -346,17 +346,8 @@ In an implementation for Java:
 
 [WARNING]
 ====
-When working with NoSQL databases, the support for arithmetic operations and support of parentheses for precedence might vary significantly:
-
-Key-value databases:: Arithmetic operations (`+`, `-`, `*`, `/`) are not supported. These databases are designed for simple key-based lookups and lack query capabilities for complex operations.
-
-Wide-column databases:: Arithmetic operations are not required to be supported. Some wide-column databases might offer limited support, which might require secondary indexing even for basic querying.
-
-Document Databases:: Support of arithmetic operations and support of parenthesis for precedence are not required, although databases typically offer these capabilities. Behavior and extent of support can vary significantly between providers.
-
-Graph Databases:: Support for arithmetic operations and parentheses for precedence are not required but is typically offered by databases. Behavior and extent of support can vary significantly between providers.
-
-Due to the diversity of NoSQL database types and their querying capabilities, there is no guarantee that all NoSQL providers will support punctuation characters such as parentheses `(`, `)` for defining operation precedence. It is recommended to consult your NoSQL provider's documentation to confirm the supported query features and their behavior.
+When a Jakarta Query implementation targets a non-relational database, support for arithmetic operators or support for the use of parentheses to control operator precedence might vary from what is described above.
+This specification does not require support for arithmetic operators or grouping parentheses if the underlying datastore does not provide these features among its native querying capabilities.
 ====
 
 [[subquery-expressions]]
@@ -502,13 +493,11 @@ In the extended language, the right operand of an equality or inequality operato
 
 [WARNING]
 ====
-When using NoSQL databases, there are limitations to the support of equality and inequality operators:
+When a Jakarta Query implementation targets a non-relational database, support for equality and inequality operators might vary from what is described above.
+This specification does not require support for use of an equality or inequality operator if the underlying datastore does not provide this operator in its native querying capabilities.
+For example, some non-relational databases might only allow lookup by key, and in such databases only the entity <<structures-and-records,identifier>> may be used in an equality comparison expression.footnote:[In Jakarta NoSQL, the key attribute is identified by the annotation `jakarta.nosql.Id`.]
 
-1. **Key-Value Databases**: Support for the equality restriction on the key attribute is required. The key attribute is defined by the annotation `jakarta.nosql.Id`. Key-value databases are not required to support any other restrictions.
-
-2. **Wide-Column Databases**: Support for equality restriction and the inequality restriction on the `Id` attribute is required. Support for restrictions on other entity attributes is not required. These operations typically work only with the `Id` by default but might be compatible for other entity attributes if secondary indexes are configured in the database schema.
-
-3. **Graph and Document Databases**: Support for all equality and inequality operators is required.
+**TODO** Why does Jakarta Data not have a similar caveat applying to `between`, `like`, `in`, and  `is null`? Do we need to generalize the language above to other sorts of conditional expressions?
 ====
 
 [[quantifiers]]
@@ -579,9 +568,6 @@ Syntactically, logical operators are parsed with lower precedence than <<Equalit
 
 [WARNING]
 ====
-When using NoSQL databases, the support for restrictions varies depending on the database type:
-
-Key-value databases:: Support for the equality restriction is required for the `Id` attribute. There is no requirement to support other types of restrictions or restrictions on other entity attributes.
-Wide-column databases:: Wide-column databases are not required to support the `AND` operator or the `OR` operator. Restrictions must be supported for the key attribute that is annotated with `jakarta.nosql.Id`. Support for restrictions on other attributes is not required. Typically they can be used if they are indexed as secondary indexes, although support varies by database provider.
-Graph and document databases:: The `AND` and `OR` operators and all of the restrictions described in this section must be supported. Precedence between `AND` and `OR` operators is not guaranteed and may vary significantly based on the NoSQL provider.
+When a Jakarta Query implementation targets a non-relational database, support for logical operators might vary from what is described above.
+This specification does not require support for logical operators if the underlying datastore does not provide a functionally equivalent way to restrict query results among its native querying capabilities.
 ====

--- a/spec/src/main/asciidoc/chapters/language/statements.adoc
+++ b/spec/src/main/asciidoc/chapters/language/statements.adoc
@@ -154,13 +154,8 @@ A query beginning with `select count(this)` performs aggregation (without groupi
 
 [WARNING]
 ====
-When working with NoSQL databases, the `select` clause behavior may vary depending on the database structure and capabilities:
-
-Key-value databases:: These databases generally do not support `select` clauses beyond retrieving values by their keys. Support for complex path expressions and aggregate functions like `count(this)` is not required.
-
-Wide-column databases:: The ability to use a `select` clause may depend on the presence of secondary indexes. Without secondary indexes, selection is often restricted to key-based operations. Support for `count(this)` is not required.
-
-Graph and document databases:: Support for flexible `select` clauses, including path expressions and aggregate functions like `count(this)` is required. Performance might vary based on the size and indexing of the dataset.
+When a Jakarta Query implementation targets a non-relational database, support for projection might vary from what is described above.
+In particular, this specification does not require support for `count(this)` if the underlying datastore only provides for key-based lookups.
 ====
 
 In the extended language, the `select` clause is much more flexible.
@@ -176,7 +171,7 @@ If the `#distinct#` keyword occurs, then projection is followed by duplicate eli
 [[set-clause]]
 ==== Set clause
 
-The `set` clause, with syntax given by `set_clause`, specifies a list of updates to attributes of the queried entity. For each record which satisfies the restriction imposed by the `where` clause, and for each element of the list, the scalar expression is evaluated and assigned to the entity attribute identified by the path expression.
+The `set` clause, with syntax given by `set_clause`, specifies a list of updates to attributes of the queried entity. For each record satisfying the restriction imposed by the `where` clause, and for each element of the list, the scalar expression is evaluated and assigned to the entity attribute identified by the path expression.
 
 [[order-clause]]
 ==== Order clause
@@ -207,24 +202,13 @@ The `order` clause is always optional. When it is missing, the order of the quer
 
 NOTE: An implementation of Jakarta Query might provide some other facility to specify sorting criteria for the results of a given query. For example, Jakarta Query allows an object carrying sorting criteria to be passed as an argument to a repository method.
 
-NOTE: If a datastore does not natively provide the ability to sort query results, the Jakarta Query provider is strongly encouraged, but not required, to sort the query results in Java before returning the results to the client.
-
 [WARNING]
 ====
-When using NoSQL databases, sorting support varies by database type:
-
-Key-value databases:: Sorting of results is not supported.
-
-Wide-column databases:: Support for sorting of results is not required. In general, sorting is not natively supported. When sorting is available, it is typically limited to:
-* The key attribute, defined by an annotation such as `jakarta.nosql.Id`.
-* Fields that are indexed as secondary indexes.
-
-Graph and document databases:: Support for sorting by a single entity attribute is required. Support for compound sorting (sorting by multiple entity attributes) is not required and may vary due to:
-* Potential instability with tied values, where sorting for equivalent values may differ across queries.
-* Schema flexibility and mixed data types.
-* Dependence on indexes and internal storage order, requiring proper indexing to ensure predictable sorting.
-* The distributed nature of sharded clusters, where sorting across shards may introduce additional complexity.
+When a Jakarta Query implementation targets a non-relational database, support for sorting query results might vary from what is described above.
+This specification does not require support for sorting a query result list according to a given ordering if the underlying datastore does not provide a way to sort query results according to that ordering via its native querying capabilities.
 ====
+
+NOTE: If a datastore does not natively provide the ability to sort query results, the Jakarta Query provider is strongly encouraged, but not required, to sort the query results in Java before returning the results to the client.
 
 [[union-intersect-except]]
 === Union, intersect, and except
@@ -295,9 +279,8 @@ Such functionality falls outside the scope of this specification.
 
 [WARNING]
 ====
-A NoSQL database might not be capable of conditional updates or might not be able to determine the number of matching records reliably for an `update` operation that returns an `int` or `long`.
-
-Additionally, in databases with **append-only semantics**—such as many time-series and wide-column databases—the `update` operation may behave more like an `insert`, and repeated updates to the same record might not overwrite previous values.
+A Jakarta Query implementation which targets a non-relational database might not support conditional updates.
+This specification does not require support for conditional updates if the underlying datastore does not provide a functionally equivalent capability.footnote:[Alternatively, in a non-relational database with _append-only semantics_ -- common in time-series and wide-column databases -- conditional updates might be provided, but the update operation might behave more like an insert operation, with repeated updates to the same record not overwriting previous values.]
 ====
 
 ==== Delete statements
@@ -309,6 +292,7 @@ Such functionality falls outside the scope of this specification.
 
 [WARNING]
 ====
-A NoSQL database might not be capable of the execution of conditional deletes or might not be able to determine the number of deleted records reliably for a `delete` operation.
+A Jakarta Query implementation which targets a non-relational database might not support conditional deletes.
+This specification does not require support for conditional deletes if the underlying datastore does not provide a functionally equivalent capability.
 ====
 


### PR DESCRIPTION
In Jakarta Data we explicitly enumerated the various kinds of datastore, and this made sense because Jakarta Data has a TCK whose requirements vary by database type. But here we have no TCK, and so these admonitions provided TMI.