### PR TITLE
persistence spec says parameters can be repeated

### DIFF
--- a/spec/src/main/asciidoc/chapters/language/expressions.adoc
+++ b/spec/src/main/asciidoc/chapters/language/expressions.adoc
@@ -58,6 +58,8 @@ NOTE: This specification does not define how arguments are assigned to parameter
 
 When executed, a parameter expression evaluates to the argument assigned to the parameter.
 
+A given named or positional parameter may occur more than once in a query.
+
 Positional and named parameters must not be mixed in a single query.
 
 [[enum-literals]]


### PR DESCRIPTION
This is a requirement dating back to the first version of JPA.